### PR TITLE
Fix pipeline extension check

### DIFF
--- a/Vulnerability/main.py
+++ b/Vulnerability/main.py
@@ -66,7 +66,7 @@ def run_pipeline(input_file: str):
     # Determine file type based on its extension
     ext = os.path.splitext(input_file)[1].lower()
 
-    if ext == [".pcap", ".pcapng", ".pcapppi"]:
+    if ext in [".pcap", ".pcapng", ".pcapppi"]:
         run_pcap_pipeline(input_file)
     elif ext == ".xml":
         run_nmap_pipeline(input_file)


### PR DESCRIPTION
## Summary
- fix check for PCAP file extensions in vulnerability pipeline

## Testing
- `python -m py_compile Vulnerability/main.py`
- `find Vulnerability -name '*.py' -print0 | xargs -0 python -m py_compile`


------
https://chatgpt.com/codex/tasks/task_e_6857082a7ab48332829f94adb8f0627f