### PR TITLE
Fix example pcap path

### DIFF
--- a/Vulnerability/core/pcap_extractor.py
+++ b/Vulnerability/core/pcap_extractor.py
@@ -68,6 +68,6 @@ def export_pcap_to_csv(pcap_path: str, output_csv: str, display: bool = True) ->
 # If this script is executed directly, run an example extraction
 if __name__ == "__main__":
     # These paths should be updated to match your local environment
-    pcap = r"path\to\your\input..pcap"
+    pcap = r"path\to\your\input.pcap"
     output = r"path\to\your\output.csv"
     export_pcap_to_csv(pcap, output)


### PR DESCRIPTION
## Summary
- fix typo in example input path in `pcap_extractor.py`

## Testing
- `pytest -q`
- `python -m py_compile Vulnerability/core/pcap_extractor.py`


------
https://chatgpt.com/codex/tasks/task_e_6857093787dc83329ada775fae787ba9